### PR TITLE
fix parameter typo, which makes the trading API unavailable

### DIFF
--- a/src/PPC.php
+++ b/src/PPC.php
@@ -46,7 +46,7 @@ class PPC
         $this->apiSecret = $apiSecret;
 
         if ($this->apiKey) {
-            $this->enablePrivate = true;
+            $this->enableTrading = true;
         }
 
         $defaultOptions = [

--- a/tests/PPCTest.php
+++ b/tests/PPCTest.php
@@ -111,6 +111,27 @@ class PPCTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(is_array($result->decoded));
     }
 
+    /**
+     * @author Andreas Glaser
+     *
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Trading request are not possible if api key and secret have not been set
+     */
+    public function testTradingException()
+    {
+        (new PPC())->getBalances();
+    }
+
+    /**
+     * @author Andreas Glaser
+     *
+     * @expectedException \GuzzleHttp\Exception\ClientException
+     */
+    public function testTradingExceptionWithApiKey()
+    {
+        (new PPC('dummy', 'dummy'))->getBalances();
+    }
+
 //    /**
 //     * @author Andreas Glaser
 //     * @group  this


### PR DESCRIPTION
Looks like a renamed class parameter. But because the wrong parameter is set, the trading calls are therefore unavailable. (Added test to show the problem)